### PR TITLE
Fix r: r chat lookups, NodeSource build break, missing logs dir, and run.sh cwd loss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN npm install
 # Copy your app code
 COPY . .
 
+# logs/ is gitignored, so it is absent from clean checkouts
+RUN mkdir -p /app/logs
+
 # Prevent Node Module Version Errors
 RUN npm rebuild --unsafe-perm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,17 @@ RUN apt-get update && apt-get upgrade -y && \
       libcairo2-dev libpango1.0-dev libpng-dev libgif-dev librsvg2-dev zlib1g-dev \
       libjpeg-dev python3 wget ffmpeg
 
-# Install Node.js 22 (NodeSource)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get update && apt-get install -y nodejs
+# Install Node.js 22 from the official nodejs.org tarball.
+# deb.nodesource.com serves 403 (S3 AccessDenied); its setup script also failed silently
+# here, because `curl | bash` reports bash's status and apt then installed Ubuntu's
+# nodejs without npm, so the build only broke later at `npm install`.
+ENV NODE_VERSION=22.23.1
+ENV NODE_SHA256=9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578
+RUN curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+ && echo "${NODE_SHA256}  node-v${NODE_VERSION}-linux-x64.tar.xz" | sha256sum -c - \
+ && tar -xJf "node-v${NODE_VERSION}-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+ && rm "node-v${NODE_VERSION}-linux-x64.tar.xz" \
+ && node --version && npm --version
 
 # Install Google Chrome stable
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O 
 WORKDIR /app
 
 # Copy and install Node dependencies
+# patches/ must land before npm install so the postinstall hook can apply it
 COPY package*.json ./
+COPY patches ./patches
 RUN npm install
 
 # Copy your app code

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "main": "index.js",
     "scripts": {
         "start": "node index.js",
-        "test": "jest"
+        "test": "jest",
+        "postinstall": "patch-package"
     },
     "dependencies": {
         "biblia-interface": "^2.0.2",
@@ -17,6 +18,7 @@
     },
     "devDependencies": {
         "jest": "^30.2.0",
-        "npm-check-updates": "^18.1.1"
+        "npm-check-updates": "^18.1.1",
+        "patch-package": "^8.0.0"
     }
 }

--- a/patches/whatsapp-web.js+1.34.7.patch
+++ b/patches/whatsapp-web.js+1.34.7.patch
@@ -1,0 +1,121 @@
+diff --git a/node_modules/whatsapp-web.js/src/util/Injected/Utils.js b/node_modules/whatsapp-web.js/src/util/Injected/Utils.js
+index dfa30a579de..8be27590879 100644
+--- a/node_modules/whatsapp-web.js/src/util/Injected/Utils.js
++++ b/node_modules/whatsapp-web.js/src/util/Injected/Utils.js
+@@ -582,7 +582,7 @@ exports.LoadUtils = () => {
+ 
+         return window
+             .require('WAWebCollections')
+-            .Msg.get(newMsgKey._serialized);
++            .Msg.get(window.WWebJS.getMsgKeyId(newMsgKey));
+     };
+ 
+     window.WWebJS.editMessage = async (msg, content, options = {}) => {
+@@ -625,7 +625,9 @@ exports.LoadUtils = () => {
+         await window
+             .require('WAWebSendMessageEditAction')
+             .sendMessageEdit(msg, content, internalOptions);
+-        return window.require('WAWebCollections').Msg.get(msg.id._serialized);
++        return window
++            .require('WAWebCollections')
++            .Msg.get(window.WWebJS.getMsgKeyId(msg.id));
+     };
+ 
+     window.WWebJS.toStickerData = async (mediaInfo) => {
+@@ -834,6 +836,20 @@ exports.LoadUtils = () => {
+             });
+         }
+ 
++        // The rename reaches the serialized model too: `msg.id` comes back carrying `$1` and no
++        // `_serialized`, so every consumer of `message.id._serialized` — including this library's own
++        // Message structure and anything keyed on a message id — silently receives undefined. Restore
++        // it here, where `msg.id.remote` is already normalised, so the whole downstream surface keeps
++        // working rather than each caller having to know about `$1`.
++        if (typeof msg.id === 'object' && msg.id._serialized == null) {
++            const serializedId = window.WWebJS.getMsgKeyId(msg.id);
++            if (serializedId) {
++                msg.id = Object.assign({}, msg.id, {
++                    _serialized: serializedId,
++                });
++            }
++        }
++
+         delete msg.pendingAckUpdate;
+ 
+         return msg;
+@@ -917,12 +933,34 @@ exports.LoadUtils = () => {
+         };
+     };
+ 
++    /**
++     * The serialized id of a message key, tolerating WhatsApp Web having renamed the key's
++     * `_serialized` property to `$1`. Reading the old name now returns `undefined`, which reaches
++     * IndexedDB as a `.get(undefined)` and throws
++     * `DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified.`
++     * `_serialized` is preferred so nothing changes wherever it is still present (chat ids, for
++     * example, are unaffected by the rename). Returns undefined when neither exists, so callers can
++     * skip the lookup instead of querying a store with a nullish key.
++     * @param {Object} key a message key, e.g. `chat.lastReceivedKey` or a raw `msg.id`
++     * @returns {string|undefined}
++     */
++    window.WWebJS.getMsgKeyId = (key) =>
++        key?._serialized ?? key?.$1 ?? undefined;
++
+     window.WWebJS.getChats = async () => {
+         const chats = window.require('WAWebCollections').Chat.getModelsArray();
+-        const chatPromises = chats.map((chat) =>
+-            window.WWebJS.getChatModel(chat),
+-        );
+-        return await Promise.all(chatPromises);
++
++        // Process each chat individually — one failure should not discard every chat
++        const results = [];
++        for (const chat of chats) {
++            try {
++                const model = await window.WWebJS.getChatModel(chat);
++                if (model) results.push(model);
++            } catch {
++                // skip chats that fail serialization (e.g. LID-based group metadata issues)
++            }
++        }
++        return results;
+     };
+ 
+     window.WWebJS.getChannels = async () => {
+@@ -957,7 +995,12 @@ exports.LoadUtils = () => {
+             const groupMetadata =
+                 window.require('WAWebCollections').GroupMetadata ||
+                 window.require('WAWebCollections').WAWebGroupMetadataCollection;
+-            await groupMetadata.update(chatWid);
++            try {
++                await groupMetadata.update(chatWid);
++            } catch {
++                // LID-based chat IDs may not be found in IndexedDB — skip group metadata
++                model.groupMetadata = null;
++            }
+             const { toPn } = window.require('WAWebLidMigrationUtils');
+             const serializedMetadata = chat.groupMetadata.serialize();
+             for (const p of serializedMetadata.participants || []) {
+@@ -981,16 +1024,17 @@ exports.LoadUtils = () => {
+ 
+         model.lastMessage = null;
+         if (model.msgs && model.msgs.length) {
+-            const lastMessage = chat.lastReceivedKey
++            const lastReceivedKeyId = window.WWebJS.getMsgKeyId(
++                chat.lastReceivedKey,
++            );
++            const lastMessage = lastReceivedKeyId
+                 ? window
+                       .require('WAWebCollections')
+-                      .Msg.get(chat.lastReceivedKey._serialized) ||
++                      .Msg.get(lastReceivedKeyId) ||
+                   (
+                       await window
+                           .require('WAWebCollections')
+-                          .Msg.getMessagesById([
+-                              chat.lastReceivedKey._serialized,
+-                          ])
++                          .Msg.getMessagesById([lastReceivedKeyId])
+                   )?.messages?.[0]
+                 : null;
+             lastMessage &&

--- a/run.sh
+++ b/run.sh
@@ -1,32 +1,14 @@
 #!/bin/bash
 
-TARGET_DIR="./.wwebjs_auth/session/"
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="$APP_DIR/.wwebjs_auth/session"
+
+cd "$APP_DIR" || exit 1
 
 until npm start; do
-    echo Something went wrong. Retrying in 5 seconds...
-    # Relative path where deletion should happen
-    PATTERN="Singleton*"
-
-    # Check directory exists
-    if [ ! -d "$TARGET_DIR" ]; then
-        echo "Error: Directory does not exist: $TARGET_DIR"
-    fi
-
-    # Move into the directory
-    cd "$TARGET_DIR" || {
-        echo "Error: Cannot enter directory $TARGET_DIR"
-    }
-
-    # Check if pattern matches any files
-    if ! compgen -G "$PATTERN" > /dev/null; then
-        echo "Error: No files found matching '$PATTERN' in $TARGET_DIR"
-    fi
-
-    # Delete matching files
-    if rm $PATTERN; then
-        echo "Files deleted successfully."
-    else
-        echo "Error: Failed to delete files matching '$PATTERN'"
-    fi
+    echo "Something went wrong. Retrying in 5 seconds..."
+    # LocalAuth may have deleted the session dir we were standing in
+    cd "$APP_DIR" || exit 1
+    rm -f "$TARGET_DIR"/Singleton*
     sleep 5
 done


### PR DESCRIPTION
Four fixes. A test image is pushed as `jeffrey12cali/whatsapp-frankenstein-bot:pr-4` (also `:c477cc9`); `:latest` is deliberately untouched.

## 1. Build is broken: NodeSource returns 403

`deb.nodesource.com` serves HTTP 403 for the entire domain — a genuine S3 `AccessDenied` from their bucket, not a local network issue. The setup script cannot be fetched, so **the image cannot be built at all, including by `.github/workflows/docker-publish.yml`**.

The failure was also silent. `curl -fsSL … | bash -` reports *bash's* exit status, not curl's, so the `&&` chain continued after curl died and `apt-get install -y nodejs` installed Ubuntu's nodejs package — which does not include npm. The build then died four steps later at `RUN npm install` with `npm: not found`, pointing at the wrong line.

Now fetches the official nodejs.org tarball, pinned to **22.23.1** (the version the image already shipped), verified against the published `SHASUMS256.txt`, with `node --version && npm --version` in the same layer so a bad install fails at the right step.

Trade-off: `setup_22.x` tracked the latest 22.x automatically; this pins one version, so builds become reproducible but bumping Node is a deliberate edit. Revert this commit if NodeSource recovers and you prefer auto-tracking.

## 2. `r: r` on every chat lookup

WhatsApp Web renamed the message-key field `_serialized` to `$1`. The injected `Utils.js` still reads `_serialized`, gets `undefined`, and passes that to `Msg.get(undefined)`, which throws an IndexedDB `DataError`. Puppeteer surfaces it minified as `r: r`.

| Trace | Our call site |
|---|---|
| `Client.getChatById` | `models/User.js:74` (`setChat`), `models/User.js:53` (`setCommands`) |
| `Message.getQuotedMessage` | `commands/YtDlp.js:157` |

Result: `!ytvid` on a quoted link fails (`init` throws, `Context.startCommand` catches it, `completed` stays false, prints `Sin éxito`), and chat/command logging silently fails. The same rename breaks LID chat IDs, which is the `Number not valid` at `models/User.js:30`.

Upstream is [wwebjs/whatsapp-web.js#201845](https://github.com/wwebjs/whatsapp-web.js/issues/201845); the fix is [PR #201850](https://github.com/wwebjs/whatsapp-web.js/pull/201850). **That PR is still open and not on `main`**, so rebuilding against `#main` does not help. This vendors the diff with `patch-package`. `patches/` is copied before `npm install` so the `postinstall` hook can see it during the build.

**Revert when upstream merges:** delete `patches/whatsapp-web.js+1.34.7.patch`, the `postinstall` script, and the `patch-package` devDependency. Because the dependency tracks `#main`, the patch needs refreshing if upstream touches `Utils.js` first — `patch-package` fails loudly rather than skipping silently.

## 3. `ENOENT: open './logs/log.txt'`

`logs/` is gitignored (`.gitignore` lines 9 and 67), so it is absent from a clean checkout and never reaches the build context. `utils/utils.js:13` writes with `{ flag: 'a' }`, which creates a missing *file* but not a missing *parent directory*. Caught at `utils/utils.js:14`, so not fatal — logging simply never worked on images built from a clone. Fixed by creating `/app/logs` at build time.

## 4. Retry loop wedges with `ENOENT: uv_cwd`

`run.sh` `cd`'d into `./.wwebjs_auth/session/` for its `Singleton*` cleanup and never returned. `LocalAuth.logout()` does `fs.promises.rm(userDataDir, { recursive: true, force: true })` on that exact directory, so the shell's cwd could be deleted underneath it. Afterwards every relative path resolved from a deleted inode and `npm` aborted on `process.cwd()`, requiring a container restart:

```
./run.sh: line 16: cd: ./.wwebjs_auth/session/: No such file or directory
Error: ENOENT: no such file or directory, uv_cwd
```

Fixed with absolute paths and a cwd reset each iteration. Branches that only echoed and continued were dropped — `rm -f` already handles missing-directory and no-match cases. This also removes a second possible cause of the `./logs` ENOENT above, since cwd drift broke every relative path.

## Verification

Built for `linux/amd64` and inspected inside the image:

- `node v22.23.1`, `npm 10.9.8`, tarball checksum `OK`
- `patch-package 8.0.1 → whatsapp-web.js@1.34.7 ✔`, `getMsgKeyId` present in the installed `Utils.js`
- `/app/logs` present; `writeLog()` smoke test actually writes instead of throwing
- `run.sh` in the image is the fixed version; Chrome 150.0.7871.186, yt-dlp 2026.07.04, ffmpeg 6.1.1 all present
- `node --check index.js` passes

Not verified against live WhatsApp Web — that needs a paired session, which is what the `pr-4` image is for.

## Known gap, not fixed here

`commands/Trim.js:8` uses `trim_path = "./trim"`. `trim/` has zero tracked files and is not bind-mounted by any compose file, and there is no `mkdir` anywhere in the app code, so `!trim` will hit the same ENOENT class of bug. Left alone to keep this PR to what was diagnosed.